### PR TITLE
Rails credentials support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
     $ gem install instant18n
 
-Make sure to set `OPENAI_ACCESS_TOKEN` in your environment so that the library is able to access GPT.
+Make sure to set `OPENAI_ACCESS_TOKEN` environment variable or `openai_access_token` in your Rails credentials file so that the library is able to access GPT.
 
 ## Usage
 

--- a/lib/i18n_extensions.rb
+++ b/lib/i18n_extensions.rb
@@ -98,10 +98,14 @@ module I18n
   end
 
   def self.openai_client
-    @client ||= OpenAI::Client.new(access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"))
+    @client ||= OpenAI::Client.new(access_token: openai_access_token)
   end
 
   def self.gpt_message(role, content)
     { role: role.to_s, content: content }
+  end
+
+  def self.openai_access_token
+    ENV.fetch("OPENAI_ACCESS_TOKEN", Rails.application.credentials.openai_access_token)
   end
 end


### PR DESCRIPTION
Adds support for optionally setting the OpenAI access token through your Rails credentials file, instead of OPENAI_ACCESS_TOKEN environment variable. 